### PR TITLE
Viikon 3 palaute

### DIFF
--- a/MatvejeffTeemu/viikko3.txt
+++ b/MatvejeffTeemu/viikko3.txt
@@ -1,0 +1,6 @@
+Tämän viikon kohdalla suurin yksittäinen moitteen sija oli
+paja-tuntien ilmoittaminen ja sijoittelu. Sen lisäksi että
+tieto tuli viime hetkellä (siis sunnuntai-iltana myöhään)
+niin ensimmäisen pajatunnin laittaminen maanantai-iltaan
+oli omasta mielestä ikävästi tehty ja tästä johtuen paja-
+tunnit jäivät tällä kertaa väliin.


### PR DESCRIPTION
Tämän viikon kohdalla suurin yksittäinen moitteen sija oli
paja-tuntien ilmoittaminen ja sijoittelu. Sen lisäksi että
tieto tuli viime hetkellä (siis sunnuntai-iltana myöhään)
niin ensimmäisen pajatunnin laittaminen maanantai-iltaan
oli omasta mielestä ikävästi tehty ja tästä johtuen paja-
tunnit jäivät tällä kertaa väliin.
